### PR TITLE
Fix output_files initialization in cleanup.py

### DIFF
--- a/cleanup.py
+++ b/cleanup.py
@@ -11,7 +11,8 @@ if os.path.exists(OUTPUT_DIR):
     output_files = os.listdir(OUTPUT_DIR)
 else:
     print(f"Directory {OUTPUT_DIR} does not exist. Skipping cleanup.")
-
+    output_files = []
+    
 for filename in output_files:
     
     if filename.endswith('.html'):


### PR DESCRIPTION
Initialize output_files as an empty list if the directory exists.